### PR TITLE
bubble chart tooltips will be html rendered

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -33,3 +33,12 @@ p, ul {
 }
 
 .modal-dialog h4 { margin: 0 }
+
+/* 
+ * The style rules bellow will hide bubblechart tooltips third elements that currently
+ * happens to be the duplicated field. !!!Warning: this is a temporary visual fix,
+ * this style can lead to errors
+ */
+#chart-bubble-courses > div > div:last-child li:nth-child(3){
+  display:none;
+}

--- a/app/views/transcripts/charts/_bubble_courses.html.haml
+++ b/app/views/transcripts/charts/_bubble_courses.html.haml
@@ -1,5 +1,13 @@
 #chart-bubble-courses.chart
 
+<!-- This style will hide bubblechart tooltips third elements that currently happens 
+to be the duplicated field. !!!Warning: this is a temporary visual fix, this style can lead to errors -->
+<style>
+  div#chart-bubble-courses > div > div:last-child li:nth-child(3){
+    display:none;
+  }
+</style>
+
 = content_for :js_code do
   :javascript
     google.charts.setOnLoadCallback(drawBubbleCoursesChart);
@@ -10,6 +18,7 @@
 
       // Set chart options
       var options = {
+        tooltip: { isHtml: true }, //It will make the chart tooltip be html rendered instead of svg rendered
         title: 'Disciplinas cursadas ao longo dos semestres',
         titleTextStyle: { fontSize: 19 },
         hAxis: {

--- a/app/views/transcripts/charts/_bubble_courses.html.haml
+++ b/app/views/transcripts/charts/_bubble_courses.html.haml
@@ -1,13 +1,5 @@
 #chart-bubble-courses.chart
 
-<!-- This style will hide bubblechart tooltips third elements that currently happens 
-to be the duplicated field. !!!Warning: this is a temporary visual fix, this style can lead to errors -->
-<style>
-  div#chart-bubble-courses > div > div:last-child li:nth-child(3){
-    display:none;
-  }
-</style>
-
 = content_for :js_code do
   :javascript
     google.charts.setOnLoadCallback(drawBubbleCoursesChart);
@@ -18,9 +10,9 @@ to be the duplicated field. !!!Warning: this is a temporary visual fix, this sty
 
       // Set chart options
       var options = {
-        tooltip: { isHtml: true }, //It will make the chart tooltip be html rendered instead of svg rendered
         title: 'Disciplinas cursadas ao longo dos semestres',
         titleTextStyle: { fontSize: 19 },
+        tooltip: { isHtml: true },
         hAxis: {
           title: 'Semestre',
           ticks: $.map(gon.bubble, function(val) { return val[1] }),


### PR DESCRIPTION
Since bubble charts tooltips aren't customizable, that was the only way I could think of to solve the duplicated field issue.

Bubble chart tooltips will be html rendered which allows you to customize its style and content in an easier way, including hiding elements. You may need to re-style your tooltip for this graph, but I don't think this is going to be a problem.

I'm not familiar with ruby on rails thats why I edited the file with pure html and css. Feel free to refuse this request and apply the idea in a proper way or just refuse the whole thing x)
